### PR TITLE
Adding reindex.sh to perform the initialization required to run gosu …

### DIFF
--- a/zend/Dockerfile
+++ b/zend/Dockerfile
@@ -37,6 +37,9 @@ EXPOSE 18231
 # option (folder ownership will be changed to the same UID/GID as provided by the docker run command)
 VOLUME ["/mnt/zen"]
 
+## Alternate entrypoint, in case you need to reindex
+COPY reindex.sh /usr/local/bin/reindex.sh
+
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 

--- a/zend/reindex.sh
+++ b/zend/reindex.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+# Add local user
+# Either use the LOCAL_USER_ID if passed in at runtime or
+# fallback
+USER_ID=${LOCAL_USER_ID:-9001}
+GRP_ID=${LOCAL_GRP_ID:-9001}
+
+getent group user > /dev/null 2>&1 || groupadd -g $GRP_ID user
+id -u user > /dev/null 2>&1 || useradd --shell /bin/bash -u $USER_ID -g $GRP_ID -o -c "" -m user
+
+LOCAL_UID=$(id -u user)
+LOCAL_GID=$(getent group user | cut -d ":" -f 3)
+
+if [ ! "$USER_ID" == "$LOCAL_UID" ] || [ ! "$GRP_ID" == "$LOCAL_GID" ]; then
+    echo "Warning: User with differing UID "$LOCAL_UID"/GID "$LOCAL_GID" already exists, most likely this container was started before with a different UID/GID. Re-create it to change UID/GID."
+fi
+
+echo "Starting with UID/GID : "$(id -u user)"/"$(getent group user | cut -d ":" -f 3)
+
+export HOME=/home/user
+
+# Must have a zen config file
+if [ ! -f "/mnt/zen/config/zen.conf" ]; then
+  echo "No config found. Exiting."
+  exit 1
+else
+  if [ ! -L $HOME/.zen ]; then
+    ln -s /mnt/zen/config $HOME/.zen > /dev/null 2>&1 || true
+  fi
+fi
+
+# zcash-params can be symlinked in from an external volume or created locally
+if [ -d "/mnt/zen/zcash-params" ]; then
+  if [ ! -L $HOME/.zcash-params ]; then
+    echo "Symlinking external zcash-params volume..."
+    ln -s /mnt/zen/zcash-params $HOME/.zcash-params > /dev/null 2>&1 || true
+  fi
+else
+  echo "Using local zcash-params folder"
+  mkdir -p $HOME/.zcash-params > /dev/null 2>&1 || true
+fi
+
+gosu user zend -reindex


### PR DESCRIPTION
If you run out of disk space or otherwise need to reindex for some reason, you'll need to initialize the user so that "gosu user zend -reindex" can find "user".  

Here we add a reindex.sh and copy it to /usr/local/bin/reindex.sh in the container.  This performs the initialization we find in entrypoint.sh and then runs the reindex command.  

Usage: `docker run --rm --net=host -p 9033:9033 -p 18231:18231 -v /mnt/zen:/mnt/zen --name zen-node -it --entrypoint=/usr/local/bin/reindex.sh whenlambomoon/zend:latest`