### PR TITLE
fix incorrect zen conf, adding externalip configuration

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,9 +1,10 @@
 # Parameters passed to all hosts
 [all:vars]
 email=test@example.com
+cert_email=test@example.com
 region=sea
 
 [zen-nodes]
-localhost fqdn=node.example.com stakeaddr=test nodetype=secure
+localhost fqdn=node.example.com stakeaddr=test nodetype=secure cert_domain=nodename.example.com
 
 [bootstrap-nodes]

--- a/ansible/roles/zen-node/defaults/main.yml
+++ b/ansible/roles/zen-node/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+zen_node_port: 9033

--- a/ansible/roles/zen-node/tasks/main.yml
+++ b/ansible/roles/zen-node/tasks/main.yml
@@ -156,6 +156,10 @@
   set_fact:
     servers: "{% if nodetype=='super' %}xns{% else %}ts{% endif %}"
 
+- name: Set server public IP addresses
+  set_fact:
+    externalIP_list: "$(dig $fqdn A $fqdn AAAA +short) "
+
 - name: Creating the zen secnode configuration
   template:
     src: config.json.j2

--- a/ansible/roles/zen-node/templates/zen.conf.j2
+++ b/ansible/roles/zen-node/templates/zen.conf.j2
@@ -13,7 +13,8 @@ rpcpassword={{ rpcpassword.stdout }}
 tlscertpath=/etc/letsencrypt/live/{{ fqdn }}/cert.pem
 tlskeypath=/etc/letsencrypt/live/{{ fqdn }}/privkey.pem
 
-# Add our nodes
-{% for host in groups['zen-nodes'] %}
-addnode={{ host }}
-{%endfor%}
+# add external IPs
+{% for externalIP in externalIP_list %}
+externalip={{ externalIP }}
+{% endfor %}
+port={{ zen_node_port }}


### PR DESCRIPTION
Modified the existing config template to reflect the corrected externalip setting
Added port setting to default vars - could probably go in the inventory to be consistent but then again nothing is stopping an override.
Added an example in the inventory for the certbot setup

*NOTE* I haven't run this in months, it probably wants a sanity check before any merge.